### PR TITLE
fix: make from/to/subject optional and safe header lookups

### DIFF
--- a/src/crystal-mime.cr
+++ b/src/crystal-mime.cr
@@ -8,16 +8,18 @@ module MIME
   VERSION = "0.1.17"
 
   struct Email
-    property from
-    property to
-    property subject
-    property datetime
-    property body_html
-    property body_text
-    property attachments
-    property headers
-    def initialize(@from : String, @to : String, @subject : String, @datetime : Time | Nil, 
-        @body_html : String | Nil, @body_text : String | Nil, @attachments : Array(String), @headers : Hash(String, String))
+    property from : String?
+    property to : String?
+    property subject : String?
+    property datetime : Time?
+    property body_html : String?
+    property body_text : String?
+    property attachments : Array(String)
+    property headers : Hash(String, String)
+
+    def initialize(@from : String?, @to : String?, @subject : String?, @datetime : Time?,
+                  @body_html : String?, @body_text : String?, @attachments : Array(String),
+                  @headers : Hash(String, String))
     end
   end
 
@@ -89,21 +91,19 @@ module MIME
   def self.mail_object_from_raw(raw_mime_data)
     parsed = parse_raw(raw_mime_data)
     # return Email.new(from: "", to: "", subject: "", datetime: nil, body_html: "", body_text: "", attachments: [] of String)
-    if parsed[:headers]["Date"]?
-      datetime = Time::Format::RFC_2822.parse(parsed[:headers]["Date"])
-    else
-      datetime = nil
-    end
-    # puts parsed.inspect
-    Email.new(from:     parsed[:headers]["From"],
-              to:       parsed[:headers]["To"]? || parsed[:headers]["recipient"],
-              subject:  parsed[:headers]["Subject"]? || "",    
-              datetime: datetime,
-              body_html: parsed[:parts]["text/html"]?,
-              body_text: parsed[:parts]["text/plain"]?,
-              attachments: [] of String,
-              headers: parsed[:headers]
-              )
+    datetime  = parsed[:headers]["Date"]? ?
+                  Time::Format::RFC_2822.parse(parsed[:headers]["Date"]) : nil
+
+    Email.new(
+      from:        parsed[:headers]["From"]?,
+      to:          parsed[:headers]["To"]? || parsed[:headers]["recipient"]?,
+      subject:     parsed[:headers]["Subject"]?,
+      datetime:    datetime,
+      body_html:   parsed[:parts]["text/html"]?,
+      body_text:   parsed[:parts]["text/plain"]?,
+      attachments: [] of String,
+      headers:     parsed[:headers]
+    )
   end
 
   def self.is_multipart(content_type : Nil)


### PR DESCRIPTION
## Summary

This PR fixes a crash when parsing emails that don’t include a To: or recipient header (for example, test messages generated by hMail Admin).

### Changes

- Made Email#from, #to, #subject properties String? instead of String.
- Switched header lookups (From, To, Subject) to nil-safe ([]?) to avoid KeyError.
- Allowed recipient to be absent safely.
- Updated mail_object_from_raw accordingly.
- Added a spec covering an hMail Admin test message (no To: header).

### Motivation

Real-world messages often omit some headers. The previous code raised KeyError: Missing hash key: "recipient", blocking imports. This patch allows parsing to continue gracefully with nil values.