### PR TITLE
feat: decode single-part bodies and map to body_text/body_html

### DIFF
--- a/spec/crystal-mime_spec.cr
+++ b/spec/crystal-mime_spec.cr
@@ -31,4 +31,12 @@ describe MIME do
     str = RFC2047.decode("=?UTF-8?q?Yo_=F0=9F=90=95?=")
     str.should eq("Yo 🐕")
   end
+
+  it "parses non-multipart email (quoted-printable text)" do
+    raw   = File.read("spec/test-mime2.email")
+    email = MIME.mail_object_from_raw(raw)
+
+    body = email.body_text || raise "expected body_text to be present"
+    body.chomp.should eq "Test"
+  end
 end

--- a/spec/test-mime2.email
+++ b/spec/test-mime2.email
@@ -1,0 +1,11 @@
+Return-Path: <>
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Return-Path: <>
+From: "Admin" <admin@acme.com>
+Subject: Test
+Content-Transfer-Encoding: quoted-printable
+Date: Sat, 6 Sep 2025 13:06:21 +0700
+Message-ID: <C16A5510-74D8-45FF-84BD-F2A1D2553B29@DESKTOP-R22FPGG>
+
+Test

--- a/src/crystal-mime.cr
+++ b/src/crystal-mime.cr
@@ -83,6 +83,15 @@ module MIME
       end
     else
       body = mime_io.gets_to_end
+      # Decode single-part content by Content-Transfer-Encoding (if present)
+      if cte = headers["Content-Transfer-Encoding"]?
+        case cte.downcase
+        when "quoted-printable"
+          body = QuotedPrintable.decode_string(body)
+        when "base64"
+          body = Base64.decode_string(body)
+        end
+      end
     end
 
     return { headers: headers, parts: parts, body: body }
@@ -94,21 +103,25 @@ module MIME
     datetime  = parsed[:headers]["Date"]? ?
                   Time::Format::RFC_2822.parse(parsed[:headers]["Date"]) : nil
 
-    Email.new(
-      from:        parsed[:headers]["From"]?,
-      to:          parsed[:headers]["To"]? || parsed[:headers]["recipient"]?,
-      subject:     parsed[:headers]["Subject"]?,
-      datetime:    datetime,
-      body_html:   parsed[:parts]["text/html"]?,
-      body_text:   parsed[:parts]["text/plain"]?,
-      attachments: [] of String,
-      headers:     parsed[:headers]
-    )
+    # If not multipart, parsed[:body] holds the content. Route it by Content-Type.
+    content_type = parsed[:headers]["Content-Type"]?
+    body_is_html = content_type && content_type.downcase.starts_with?("text/html")
+
+    Email.new(from:     parsed[:headers]["From"]?,
+              to:       parsed[:headers]["To"]? || parsed[:headers]["recipient"]?,
+              subject:  parsed[:headers]["Subject"]?,
+              datetime: datetime,
+              body_html: parsed[:parts]["text/html"]?  || (body_is_html ? parsed[:body] : nil),
+              body_text: parsed[:parts]["text/plain"]? || (body_is_html ? nil : parsed[:body]),
+              attachments: [] of String,
+              headers:     parsed[:headers]
+            )
   end
 
   def self.is_multipart(content_type : Nil)
     return nil
   end
+  
   def self.is_multipart(content_type : String)
     if content_type =~ /^multipart/ 
         "#{MIME::Multipart.parse_boundary(content_type)}"

--- a/src/crystal-mime.cr
+++ b/src/crystal-mime.cr
@@ -8,16 +8,18 @@ module MIME
   VERSION = "0.1.17"
 
   struct Email
-    property from
-    property to
-    property subject
-    property datetime
-    property body_html
-    property body_text
-    property attachments
-    property headers
-    def initialize(@from : String, @to : String, @subject : String, @datetime : Time | Nil, 
-        @body_html : String | Nil, @body_text : String | Nil, @attachments : Array(String), @headers : Hash(String, String))
+    property from : String?
+    property to : String?
+    property subject : String?
+    property datetime : Time?
+    property body_html : String?
+    property body_text : String?
+    property attachments : Array(String)
+    property headers : Hash(String, String)
+
+    def initialize(@from : String?, @to : String?, @subject : String?, @datetime : Time?,
+                  @body_html : String?, @body_text : String?, @attachments : Array(String),
+                  @headers : Hash(String, String))
     end
   end
 
@@ -89,21 +91,19 @@ module MIME
   def self.mail_object_from_raw(raw_mime_data)
     parsed = parse_raw(raw_mime_data)
     # return Email.new(from: "", to: "", subject: "", datetime: nil, body_html: "", body_text: "", attachments: [] of String)
-    if parsed[:headers]["Date"]?
-      datetime = Time::Format::RFC_2822.parse(parsed[:headers]["Date"])
-    else
-      datetime = nil
-    end
-    # puts parsed.inspect
-    Email.new(from:     parsed[:headers]["From"],
-              to:       parsed[:headers]["To"]? || parsed[:headers]["recipient"],
-              subject:  parsed[:headers]["Subject"]? || "",    
-              datetime: datetime,
-              body_html: parsed[:parts]["text/html"]?,
-              body_text: parsed[:parts]["text/plain"]?,
-              attachments: [] of String,
-              headers: parsed[:headers]
-              )
+    datetime  = parsed[:headers]["Date"]? ?
+                  Time::Format::RFC_2822.parse(parsed[:headers]["Date"]) : nil
+
+    Email.new(
+      from:        parsed[:headers]["From"]?,
+      to:          parsed[:headers]["To"]? || parsed[:headers]["recipient"]?,
+      subject:     parsed[:headers]["Subject"]?,
+      datetime:    datetime,
+      body_html:   parsed[:parts]["text/html"]?,
+      body_text:   parsed[:parts]["text/plain"]?,
+      attachments: [] of String,
+      headers:     parsed[:headers]
+    )
   end
 
   def self.is_multipart(content_type : Nil)


### PR DESCRIPTION
feat: decode single-part bodies and map to body_text/body_html

**Depends on:** #2 

This PR adds:
- Decoding for single-part messages when `Content-Transfer-Encoding` is `quoted-printable` or `base64`.
- Routing decoded body to `body_text` or `body_html` based on `Content-Type`.
- Spec: parses non-multipart quoted-printable text (`spec/test-mime2.email`).

Without this, non-multipart mails end up with both `body_text` and `body_html` = nil.
